### PR TITLE
add a confirmation statement to importing

### DIFF
--- a/retro/data.py
+++ b/retro/data.py
@@ -55,6 +55,7 @@ def groom_rom(rom):
 def merge(*args, quiet=True):
     import retro
     known_hashes = {}
+    imported_games = 0
     for game in retro.list_games():
         shafile = os.path.join(retro.get_game_path(game), 'rom.sha')
         with open(shafile) as f:
@@ -75,3 +76,6 @@ def merge(*args, quiet=True):
                 print('Importing', game)
             with open(os.path.join(retro.get_game_path(game), 'rom%s' % ext), 'wb') as f:
                 f.write(data)
+            imported_games += 1
+    if not quiet:
+        print('Imported %i games' % imported_games)


### PR DESCRIPTION
Hi! 
I'm not very experienced in python, so all feedback welcome!

Per the contributing guides, I consider this to be a (small) bug of core functionality. 

I spent some time last night trying to import a rom I had, because I would run the import script, see a confirmation of `Importing 3 potential games...` and then nothing else. It wasn't until I dove headfirst into the code that I found out that nothing was happening because of the sha mismatch.  My goal is to let users know if their import failed. 