### PR TITLE
close viewer when closing environment

### DIFF
--- a/retro/retro_env.py
+++ b/retro/retro_env.py
@@ -212,3 +212,7 @@ class RetroEnv(gym.Env):
     def close(self):
         if hasattr(self, 'em'):
             del self.em
+
+        if self.viewer is not None:
+            self.viewer.close()
+            self.viewer = None


### PR DESCRIPTION
When closing environment the viewer is not closed, and you have to close it with additional env.viewer.close(). 
In this PR the `viewer.close()` is called when calling `env.close()` as in most gym environments.