### PR TITLE
 Fixed the issue with the playback_movie.py script (without ffmpeg mode change)

### DIFF
--- a/retro/scripts/playback_movie.py
+++ b/retro/scripts/playback_movie.py
@@ -37,8 +37,9 @@ def playback_movie(emulator, movie, monitor_csv=None, video_file=None, viewer=No
 
     def killprocs(*args, **kwargs):
         ffmpeg_proc.terminate()
-        viewer_proc.terminate()
-        viewer_proc.wait()
+        if viewer:
+            viewer_proc.terminate()
+            viewer_proc.wait()
         raise BrokenPipeError
 
     while movie.step():


### PR DESCRIPTION
This PR fixes the issue with the [retro/retro/scripts/playback_movie.py](https://github.com/openai/retro/blob/1363ed6825ac836d3a7e57919ef0984a9ccc0ff6/retro/scripts/playback_movie.py) script. 
More description is available in #14 .
### Issue description & the Fixes in this PR:
1. The `AttributeError: 'NoneType' object has no attribute 'terminate'` is coming from [this line](https://github.com/openai/retro/blob/1363ed6825ac836d3a7e57919ef0984a9ccc0ff6/retro/scripts/playback_movie.py#L40):
`viewer_proc.terminate()`
#### Fix:
The `viewer_proc` does not exist because the `viewer` object is `None` and that is because the `--viewer` argument is not set when the `playback_movie.py`'s `main()` is called.
I modified the `killprocs(...)` method like below:
```
def killprocs(*args, **kwargs):
    ffmpeg_proc.terminate()
    if viewer:
        viewer_proc.terminate()
        viewer_proc.wait()
    raise BrokenPipeError
``` 

**NOTE**: This is a response PR to requested changes on #16. This PR does not have the ffmpeg mode change (Item 2. in #16) 