### PR TITLE
add an example of a scenario file

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,26 @@ Some non-examples:
 
 Information pertaining to reward functions and done conditions can either be specified by manually overriding functions in `retro.RetroEnv` or can be done by writing a scenario file. Scenario files contain information that is used to compute the reward function and done condition from variables defined in the information manifest. Each variable specified in the scenario file is multiplied by a `reward` value if positive and a `penalty` value if negative and then summed up to create the reward for that step. Similarly, states of these variables can be checked to see if the game is over. By default the scenario file will be loaded from `scenario.json`, but alternative scenario files can be specified in the `retro.RetroEnv` constructor.
 
+```JSON
+{
+  "done": {
+    "variables": {
+      "lives": {
+        "op": "zero"
+      }
+    }
+  },
+  "reward": {
+    "variables": {
+      "score": {
+        "reward": 10.0
+      }
+    }
+  }
+}
+```
+
+
 Scenario files are again JSON and specified with the following sections:
 
 ### `reward` section


### PR DESCRIPTION
Although the documentation has the keys for what can be defined in the the scenario file, it was im possible to create one until finding an [example](https://github.com/openai/retro/blob/master/data/SonicTheHedgehog-Genesis/scenario.json). This puts the example into the forefront. 

It also seems like you might be able to script these things, like here: https://github.com/openai/retro/blob/master/data/SonicTheHedgehog-Genesis/contest.json, but that does not seem to be documented and I couldn't get it to work. 