### PR TITLE
fix a mistake in the playback code of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ import retro
 movie = retro.Movie('SonicTheHedgehog-Genesis-GreenHillZone.Act1-0000.bk2')
 movie.step()
 
-env = retro.make(game=movie.get_game(), None, use_restricted_actions=retro.ACTIONS_ALL)
+env = retro.make(game=movie.get_game(), state=retro.STATE_NONE, use_restricted_actions=retro.ACTIONS_ALL)
 env.initial_state = movie.get_state()
 env.reset()
 


### PR DESCRIPTION
Trying the playback code gave me: 
```
  File "./scripts/render.py", line 6
    env = retro.make(game=movie.get_game(), None, use_restricted_actions=retro.ACTIONS_ALL)
                                           ^
SyntaxError: positional argument follows keyword argument
```
But adding the name of the variable fixed that error. 