### PR TITLE
Fixes a problem in the ROM import process if the directory contains >32MiB files.

### DIFF
--- a/retro/data/__init__.py
+++ b/retro/data/__init__.py
@@ -405,7 +405,7 @@ def merge(*args, quiet=True):
     for rom in args:
         try:
             data, hash = groom_rom(rom)
-        except IOError:
+        except (IOError, ValueError):
             continue
         if hash in known_hashes:
             game, ext, curpath = known_hashes[hash]


### PR DESCRIPTION
Added ValueError exception to the try/except for groom_room inside merge so the code can continue importing after finding big rom files.

Note: some original SNES roms may use up to 48MiB. Maybe updating max groom_rom size too is a good idea.