### PR TITLE
add ram observations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * add ability to use arbitrary additional integration directories
 * integration UI searches for current Python's Gym Retro data directory
 * import script can now accept files in addition to directories
+* you can now use RAM observations by sending `obs_type=retro.Observations.RAM` to `retro.make`
 
 ## 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supported platforms:
 
 - Windows 7, 8, 10
 - macOS 10.12 (Sierra), 10.13 (High Sierra), 10.14 (Mojave)
-- Linux
+- Linux (manylinux)
 
 Supported Pythons:
 

--- a/examples/random_agent.py
+++ b/examples/random_agent.py
@@ -4,16 +4,18 @@ import argparse
 import retro
 
 parser = argparse.ArgumentParser()
-parser.add_argument('game', help='the name or path for the game to run')
-parser.add_argument('state', nargs='?', help='the initial state file to load, minus the extension')
+parser.add_argument('--game', default='Airstriker-Genesis', help='the name or path for the game to run')
+parser.add_argument('--state', help='the initial state file to load, minus the extension')
 parser.add_argument('--scenario', '-s', default='scenario', help='the scenario file to load, minus the extension')
 parser.add_argument('--record', '-r', action='store_true', help='record bk2 movies')
 parser.add_argument('--verbose', '-v', action='count', default=1, help='increase verbosity (can be specified multiple times)')
 parser.add_argument('--quiet', '-q', action='count', default=0, help='decrease verbosity (can be specified multiple times)')
+parser.add_argument('--obs-type', '-o', default='image', choices=['image', 'ram'], help='the observation type, either `image` (default) or `ram`')
 parser.add_argument('--players', '-p', type=int, default=1, help='number of players/agents (default: 1)')
 args = parser.parse_args()
 
-env = retro.make(args.game, args.state or retro.State.DEFAULT, scenario=args.scenario, record=args.record, players=args.players)
+obs_type = retro.Observations.IMAGE if args.obs_type == 'image' else retro.Observations.RAM
+env = retro.make(args.game, args.state or retro.State.DEFAULT, scenario=args.scenario, record=args.record, players=args.players, obs_type=obs_type)
 verbosity = args.verbose - args.quiet
 try:
     while True:

--- a/retro/__init__.py
+++ b/retro/__init__.py
@@ -1,6 +1,5 @@
 import os
 import retro.data
-import sys
 
 from enum import Enum
 from retro._retro import Movie, RetroEmulator, core_path
@@ -32,6 +31,11 @@ class Actions(Enum):
 class State(Enum):
     DEFAULT = -1
     NONE = 0
+
+
+class Observations(Enum):
+    IMAGE = 0
+    RAM = 1
 
 
 def get_core_path(corename):

--- a/retro/retro_env.py
+++ b/retro/retro_env.py
@@ -9,8 +9,6 @@ import retro
 import retro.data
 from gym.utils import seeding
 
-from retro.data import list_games, list_states
-
 gym_version = tuple(int(x) for x in gym.__version__.split('.'))
 
 __all__ = ['RetroEnv']
@@ -196,7 +194,7 @@ class RetroEnv(gym.Env):
         return actions
 
     def step(self, a):
-        if self.img is None:
+        if self.img is None and self.ram is None:
             raise RuntimeError('Please call env.reset() before env.step()')
 
         for p, ap in enumerate(self.action_to_array(a)):
@@ -242,13 +240,15 @@ class RetroEnv(gym.Env):
             if self.viewer:
                 self.viewer.close()
             return
+
+        img = self.get_screen() if self.img is None else self.img
         if mode == "rgb_array":
-            return self.get_screen() if self.img is None else self.img
+            return img
         elif mode == "human":
             if self.viewer is None:
                 from gym.envs.classic_control.rendering import SimpleImageViewer
                 self.viewer = SimpleImageViewer()
-            self.viewer.imshow(self.img)
+            self.viewer.imshow(img)
             return self.viewer.isopen
 
     def close(self):

--- a/retro/retro_env.py
+++ b/retro/retro_env.py
@@ -159,10 +159,12 @@ class RetroEnv(gym.Env):
             self._render = self.render
             self._close = self.close
 
-    def _get_obs(self):
+    def _update_obs(self):
         if self._obs_type == retro.Observations.RAM:
+            self.ram = self.get_ram()
             return self.ram
         elif self._obs_type == retro.Observations.IMAGE:
+            self.img = self.get_screen()
             return self.img
         else:
             raise ValueError('Unrecognized observation type: {}'.format(self._obs_type))
@@ -206,10 +208,8 @@ class RetroEnv(gym.Env):
         if self.movie:
             self.movie.step()
         self.em.step()
-        self.img = self.get_screen()
         self.data.update_ram()
-        self.ram = self.get_ram()
-        ob = self._get_obs()
+        ob = self._update_obs()
         rew, done, info = self.compute_step()
         return ob, rew, bool(done), dict(info)
 
@@ -225,12 +225,9 @@ class RetroEnv(gym.Env):
             self.movie_id += 1
         if self.movie:
             self.movie.step()
-        self.img = self.get_screen()
         self.data.reset()
         self.data.update_ram()
-        self.ram = self.get_ram()
-        ob = self._get_obs()
-        return ob
+        return self._update_obs()
 
     def seed(self, seed=None):
         self.np_random, seed1 = seeding.np_random(seed)

--- a/retro/retro_env.py
+++ b/retro/retro_env.py
@@ -206,7 +206,7 @@ class RetroEnv(gym.Env):
         if self.movie:
             self.movie.step()
         self.em.step()
-        self.img = self.em.get_screen()
+        self.img = self.get_screen()
         self.data.update_ram()
         self.ram = self.get_ram()
         ob = self._get_obs()
@@ -225,7 +225,7 @@ class RetroEnv(gym.Env):
             self.movie_id += 1
         if self.movie:
             self.movie.step()
-        self.img = self.em.get_screen()
+        self.img = self.get_screen()
         self.data.reset()
         self.data.update_ram()
         self.ram = self.get_ram()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,5 +1,7 @@
+import retro
 from retro.testing import testenv, handle
 import os
+import pytest
 
 
 def test_env_create(testenv):
@@ -7,12 +9,12 @@ def test_env_create(testenv):
     assert testenv(info=json_path, scenario=json_path)
 
 
-def test_env_basic(testenv):
-    import retro
+@pytest.mark.parametrize('obs_type', [retro.Observations.IMAGE, retro.Observations.RAM])
+def test_env_basic(obs_type, testenv):
     import gym
     import numpy as np
     json_path = os.path.join(os.path.dirname(__file__), 'dummy.json')
-    env = testenv(info=json_path, scenario=json_path)
+    env = testenv(info=json_path, scenario=json_path, obs_type=obs_type)
     obs = env.reset()
     assert obs.shape == env.observation_space.shape
     obs, rew, done, info = env.step(env.action_space.sample())


### PR DESCRIPTION
Add RAM observations.

It looks like `reset()` used `self.get_screen()` instead of `self.em.get_screen()`, the crop is not supposed to apply to observations, right @endrift? 