### PR TITLE
Memory leak fix.

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -58,6 +58,9 @@ Emulator::Emulator() {
 }
 
 Emulator::~Emulator() {
+	if (m_corePath) {
+		free(m_corePath);
+	}
 	if (m_romLoaded) {
 		unloadRom();
 	}
@@ -360,7 +363,10 @@ bool Emulator::cbEnvironment(unsigned cmd, void* data) {
 		return false;
 	}
 	case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
-		*reinterpret_cast<const char**>(data) = strdup(corePath().c_str());
+		if (!s_loadedEmulator->m_corePath) {
+			s_loadedEmulator->m_corePath = strdup(corePath().c_str());
+		}
+		*reinterpret_cast<const char**>(data) = s_loadedEmulator->m_corePath;
 		return true;
 	case RETRO_ENVIRONMENT_GET_CAN_DUPE:
 		*reinterpret_cast<bool*>(data) = true;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -360,7 +360,7 @@ bool Emulator::cbEnvironment(unsigned cmd, void* data) {
 		return false;
 	}
 	case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
-		*reinterpret_cast<const char**>(data) = corePath().c_str();
+		*reinterpret_cast<const char**>(data) = strdup(corePath().c_str());
 		return true;
 	case RETRO_ENVIRONMENT_GET_CAN_DUPE:
 		*reinterpret_cast<bool*>(data) = true;

--- a/src/emulator.h
+++ b/src/emulator.h
@@ -83,6 +83,8 @@ private:
 	retro_system_av_info m_avInfo = {};
 	std::vector<retro_memory_descriptor> m_map;
 
+	char* m_corePath = nullptr;
+
 #ifdef _WIN32
 	HMODULE m_coreHandle = nullptr;
 #else


### PR DESCRIPTION
This is pulled out of #152 as @endrift suggested. I'm not sure if it's ok now even though I get no errors when I check it with valgrind (I was getting errors when I wasn't using `strdup`). Who is supposed to own the memory pointed to by `data` and free it? @endrift do you have any suggestions?