### PR TITLE
Load Movie Tests: Checks .bk2 file has a Header.txt and Core.bin before loading it.

### DIFF
--- a/src/movie-bk2.cpp
+++ b/src/movie-bk2.cpp
@@ -59,6 +59,12 @@ unique_ptr<Movie> MovieBK2::load(const string& path) {
 	if (!zip->openFile("Input Log.txt")) {
 		return nullptr;
 	}
+	if (!zip->openFile("Header.txt")) {
+		return nullptr;
+	}
+	if (!zip->openFile("Core.bin")) {
+		return nullptr;
+	}
 	return make_unique<MovieBK2>(move(zip));
 }
 


### PR DESCRIPTION
When loading a recording with the extension .bk2, adding tests to check if it has a "Header.txt" and a "Core.bin" inside. Without these tests, It can end up with a Segmentation Fault. So now, I can catch this as an exception.

(I came across this issue, by calling _record_movie_ on a emulator and then closing it. This would generate a .bk2 file with only a "Core.bin" and an "Input_log.txt".)  