### PR TITLE
fix build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ os:
   - osx
 services:
   - docker
-osx_image: xcode8.3 # OS X 10.12
+osx_image: xcode9.4 # OS X 10.13
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gym Retro lets you turn classic video games into [Gym](https://gym.openai.com/) 
 Supported platforms:
 
 - Windows 7, 8, 10
-- macOS 10.12 (Sierra), 10.13 (High Sierra), 10.14 (Mojave)
+- macOS 10.13 (High Sierra), 10.14 (Mojave)
 - Linux (manylinux1)
 
 Supported Pythons:

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ class CMakeBuild(build_ext):
 platform_globs = ['*-%s/*' % plat for plat in ['Nes', 'Snes', 'Genesis', 'Atari2600', 'GameBoy', 'Sms', 'GameGear', 'PCEngine', 'GbColor', 'GbAdvance']]
 
 kwargs = {}
-if tuple(int(v) for v in setuptools_version.split('.')) >= (24, 2, 0):
+if tuple(int(v) for v in setuptools_version[:3].split('.')) >= (24, 2, 0):
     kwargs['python_requires'] = '>=3.5.0'
 
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ class CMakeBuild(build_ext):
 platform_globs = ['*-%s/*' % plat for plat in ['Nes', 'Snes', 'Genesis', 'Atari2600', 'GameBoy', 'Sms', 'GameGear', 'PCEngine', 'GbColor', 'GbAdvance']]
 
 kwargs = {}
-if tuple(int(v) for v in setuptools_version[:3].split('.')) >= (24, 2, 0):
+if tuple(int(v) for v in setuptools_version.split('.')[:3]) >= (24, 2, 0):
     kwargs['python_requires'] = '>=3.5.0'
 
 

--- a/travis.py
+++ b/travis.py
@@ -65,9 +65,7 @@ def main():
     bdist_options = []
     with Fold('script.build', 'Building'):
         if os_name == 'osx':
-            qt_prefix = subprocess.run(['brew', '--prefix', 'qt5'], encoding="utf8", stdout=subprocess.PIPE)
-            print("qt_prefix", qt_prefix)
-            cmake_options = ['-DCMAKE_PREFIX_PATH=%s' % qt_prefix, '-DBUILD_UI=ON']
+            cmake_options = ['-DCMAKE_PREFIX_PATH=/usr/local/opt/qt', '-DBUILD_UI=ON']
         elif os_name == 'linux':
             cmake_options = ['-DBUILD_MANYLINUX=ON',
                              '-DPYTHON_INCLUDE_DIR=%s/include/python%sm' % (sys.base_prefix, os.environ['PYVER'])]

--- a/travis.py
+++ b/travis.py
@@ -65,7 +65,9 @@ def main():
     bdist_options = []
     with Fold('script.build', 'Building'):
         if os_name == 'osx':
-            cmake_options = ['-DCMAKE_PREFIX_PATH=/usr/local/opt/qt', '-DBUILD_UI=ON']
+            qt_prefix = subprocess.run(['brew', '--prefix', 'qt5'], encoding="utf8", stdout=subprocess.PIPE)
+            print("qt_prefix", qt_prefix)
+            cmake_options = ['-DCMAKE_PREFIX_PATH=%s' % qt_prefix, '-DBUILD_UI=ON']
         elif os_name == 'linux':
             cmake_options = ['-DBUILD_MANYLINUX=ON',
                              '-DPYTHON_INCLUDE_DIR=%s/include/python%sm' % (sys.base_prefix, os.environ['PYVER'])]


### PR DESCRIPTION
It looks like the build is currently failing due to brew/qt not supporting the version of mac os x we are building on:

https://travis-ci.org/openai/retro/jobs/638664802#L166

`Sorry, "rcc" cannot be run on this version of macOS. Qt requires macOS 10.13.0 or later, you have macOS 10.12.6.`

