### PR TITLE
fix pyglet usage of deprecated API

### DIFF
--- a/retro/examples/interactive.py
+++ b/retro/examples/interactive.py
@@ -31,8 +31,7 @@ class Interactive(abc.ABC):
             aspect_ratio = image_width / image_height
 
         # guess a screen size that doesn't distort the image too much but also is not tiny or huge
-        platform = pyglet.window.get_platform()
-        display = platform.get_default_display()
+        display = pyglet.canvas.get_display()
         screen = display.get_default_screen()
         max_win_width = screen.width * 0.9
         max_win_height = screen.height * 0.9


### PR DESCRIPTION
Untested fix for #193 

Looks like
pyglet.window.get_platform() and platform.get_default_display() were deprecated and were removed.

I replaced the later with pyglet.canvas.get_display() as explained here: 
https://github.com/pyglet/pyglet/blob/0419b96cdf818b0f28226d2818e0b03a1edb8af3/pyglet/window/__init__.py#L1812

Doing this fix qllowed me to run `python -m retro.examples.interactive --game Airstriker-Genesis` successfuly