### PR TITLE
fix: raspi installation error (openai/retro#242)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -488,6 +488,7 @@ inline void hash_combine(std::size_t& seed, const T& v) {
 	seed = b * kMul;
 }
 #elif __SIZEOF_SIZE_T__ == 4
+template<class T>
 inline void hash_combine(std::size_t& seed, const T& v) {
 	std::hash<T> hasher;
 	const std::size_t kMul = 0x9e3779b9;


### PR DESCRIPTION
The template<class T> is declared just under the if statement so if the code reaches the elif at line 490 it is out of scope.

I solved it by inserting a line after the elif (line 490) and with template<class T> so that the template is declared even when the code runs from the elif.

It should work fine if you also move the template from line 480 and place it before the if block but I didn't test that.