### PR TITLE
Fix gym dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     url='https://github.com/openai/retro',
     version=open(VERSION_PATH, 'r').read().strip(),
     license='MIT',
-    install_requires=['gym', 'pyglet>=1.3.2,==1.*'],
+    install_requires=['gym<=0.2.0', 'pyglet>=1.3.2,==1.*'],
     ext_modules=[Extension('retro._retro', ['CMakeLists.txt', 'src/*.cpp'])],
     cmdclass={'build_ext': CMakeBuild},
     packages=['retro', 'retro.data', 'retro.data.stable', 'retro.data.experimental', 'retro.data.contrib', 'retro.scripts', 'retro.import', 'retro.examples'],


### PR DESCRIPTION
It seems like gym` 0.2.0 `is the last compatible version with retro. Everything above that version ends in an error (e.g. #262)